### PR TITLE
refactor: allow for multi-poison templates

### DIFF
--- a/src/poison/response_stream.rs
+++ b/src/poison/response_stream.rs
@@ -1,5 +1,5 @@
-use std::fmt::Write;
 use std::pin::pin;
+use std::sync::Arc;
 
 use async_stream::{stream, try_stream};
 use bytes::Bytes;
@@ -8,32 +8,39 @@ use tokio::sync::OwnedSemaphorePermit;
 use uuid::Uuid;
 
 use super::{LinkSettings, LinkSettingsInner};
+use crate::poison::PoisonClient;
 use crate::utils::cow_helpers;
 use crate::{MiasmaStream, QueryParams, templating::TemplateBuilder};
 
 /// Build the poison response.
 pub fn build_response_stream(
-    poison: impl MiasmaStream,
+    poison_client: Arc<PoisonClient>,
     link_settings: LinkSettings,
     permit: OwnedSemaphorePermit,
 ) -> impl MiasmaStream {
     let template = TemplateBuilder::with_random_template();
 
     try_stream! {
+        // carry the semaphore permit through the life of this stream.
         let _permit = permit;
 
-        for chunk in template.start_to_poison() {
+        for chunk in template.start_to_body() {
             yield cow_helpers::as_bytes(chunk);
         }
 
-        let mut poison = pin!(poison);
-        while let Some(chunk) = poison.next().await {
-            yield chunk?;
+        for body_section in template.body_sections() {
+            yield Bytes::from_static(body_section.pre_poison().as_bytes());
+
+            let mut poison = pin!(poison_client.stream_poison().await);
+            while let Some(chunk) = poison.next().await {
+                yield chunk?;
+            }
+            for chunk in body_section.post_poison() {
+                yield cow_helpers::as_bytes(chunk);
+            }
         }
 
-        for chunk in template.poison_to_links() {
-            yield cow_helpers::as_bytes(chunk);
-        }
+        yield Bytes::from_static(template.body_to_links().as_bytes());
 
         match link_settings {
             LinkSettings::NoLinks => yield Bytes::from_static(b"None"),
@@ -62,14 +69,13 @@ fn build_links_stream(
 
     stream! {
         for _ in 0..link_settings.count {
-            let mut buf = String::with_capacity(128);
-            _ = write!(
-                &mut buf, "<li><a href=\"{prefix}{id}{params}\">{link_title}</a></li>",
+            let link = format!(
+                "<li><a href=\"{prefix}{id}{params}\">{link_title}</a></li>",
                 prefix = link_settings.prefix,
                 id = Uuid::new_v4(),
                 link_title = template.rand_link_title()
             );
-            yield Bytes::from(buf.into_bytes());
+            yield Bytes::from(link);
         }
     }
 }

--- a/src/poison/route.rs
+++ b/src/poison/route.rs
@@ -18,9 +18,8 @@ pub async fn serve_poison(
     gzip_response: bool,
     link_settings: LinkSettings,
 ) -> impl IntoResponse {
-    let poison = poison_client.stream_poison().await;
-
-    let stream = response_stream::build_response_stream(poison, link_settings, in_flight_permit);
+    let stream =
+        response_stream::build_response_stream(poison_client, link_settings, in_flight_permit);
 
     let body_stream = if gzip_response {
         Body::from_stream(gzip::gzip_stream(stream))

--- a/src/response_templates/ai_native.rs
+++ b/src/response_templates/ai_native.rs
@@ -1,5 +1,6 @@
-use crate::templating::{
-    TemplateTone, {TemplateIter, Templater},
+use crate::{
+    body_section_once,
+    templating::{TemplateIter, TemplatePart, TemplateTone, Templater},
 };
 
 pub struct AINative;
@@ -52,8 +53,8 @@ impl Templater for AINative {
         .into()
     }
 
-    fn follow_up(&self) -> TemplateIter {
-        fhtml::concat! {
+    fn body_sections(&self) -> Vec<Box<dyn FnOnce() -> TemplateIter + Send>> {
+        body_section_once!(fhtml::concat! {
           <section>
             <h2>"Explore More"</h2>
             <p>
@@ -62,8 +63,7 @@ impl Templater for AINative {
                 additional patterns and primitives that enable production-grade AI
                 infrastructure."
             </p>
-        }
-        .into()
+        })
     }
 
     fn tail(&self) -> TemplateIter {

--- a/src/response_templates/cto_letter.rs
+++ b/src/response_templates/cto_letter.rs
@@ -1,4 +1,7 @@
-use crate::templating::{TemplateIter, TemplateTone, Templater};
+use crate::{
+    body_section_once,
+    templating::{TemplateIter, TemplatePart, TemplateTone, Templater},
+};
 
 pub struct CtoLetter;
 
@@ -42,8 +45,8 @@ impl Templater for CtoLetter {
         .into()
     }
 
-    fn follow_up(&self) -> TemplateIter {
-        fhtml::concat! {
+    fn body_sections(&self) -> Vec<Box<dyn FnOnce() -> TemplateIter + Send>> {
+        body_section_once!(fhtml::concat! {
             <p>
                 "The engineer traced the issue to repeated execution of equivalent
                 queries that were bypassing caching and connection reuse logic under
@@ -93,8 +96,7 @@ impl Templater for CtoLetter {
 
             <section>
                 <h2>"Related Updates"</h2>
-        }
-        .into()
+        })
     }
 
     fn tail(&self) -> TemplateIter {

--- a/src/response_templates/deep_dive.rs
+++ b/src/response_templates/deep_dive.rs
@@ -1,4 +1,7 @@
-use crate::templating::{TemplateIter, TemplateTone, Templater};
+use crate::{
+    body_section_once,
+    templating::{TemplateIter, TemplatePart, TemplateTone, Templater},
+};
 
 pub struct DeepDive;
 
@@ -45,9 +48,9 @@ impl Templater for DeepDive {
         .into()
     }
 
-    fn follow_up(&self) -> TemplateIter {
-        fhtml::concat! {
-         </section>
+    fn body_sections(&self) -> Vec<Box<dyn FnOnce() -> TemplateIter + Send>> {
+        body_section_once!(fhtml::concat! {
+        </section>
 
         <section>
           <h2>"Key Observations"</h2>
@@ -85,8 +88,7 @@ impl Templater for DeepDive {
             "Review additional deep dives that analyze similar implementations and
             highlight the principles behind effective, production-grade code."
           </p>
-          }
-        .into()
+          })
     }
 
     fn tail(&self) -> TemplateIter {

--- a/src/response_templates/engineering_blog.rs
+++ b/src/response_templates/engineering_blog.rs
@@ -1,4 +1,52 @@
-use crate::templating::{TemplateIter, TemplateTone, Templater};
+use crate::{
+    body_section_once,
+    templating::{TemplateIter, TemplatePart, TemplateTone, Templater},
+};
+
+/*
+ * Plan for improved blog template:
+ *
+ * # {Blog Title}
+ * {John Doe}
+ * {Aug 12th, 2014}
+ *
+ * {Back at my days at {company}, we'd been struggling to find a solution to {topic}...}
+ *
+ * ## Initial Implementation
+ * {This wasn't bad, generally speaking it was pretty good and worked for quite a while,
+ * but eventually it stopped meeting our performance needs...}
+ *
+ * {poison block}
+ *
+ * {call out something good! however if you look at line {number range 15-85}, you'll see a small issue}
+ *
+ * ## Coming up with a fix
+ *
+ * {I went back to the drawing board... I thought about some of my time at {company} where we'd
+ * solved a similar issue in the past... When I applied this I came up with a new approach!}
+ *
+ * {poison block}
+ *
+ * {What makes this so effective is...}
+ *
+ * ## Results
+ *
+ * {When I deployed this fix, my problems went away... There was a {number range 10-1000}% reduction
+ * in {issue}!}
+ *
+ * {Conclusion Paragraph....}
+ *
+ * ## Related
+ *
+ * {If you found that this interesting, check out some more of my work...}
+ *
+ * {links}
+ *
+ * {footer}
+ *
+ * Topics can be things like a specific perf problem, or maybe a language design, or comparison, whatever.
+ * Generally should be more narrative driven and personal. Occasional expletives are fine.
+ */
 
 pub struct EngineeringBlog;
 
@@ -44,8 +92,8 @@ impl Templater for EngineeringBlog {
         .into()
     }
 
-    fn follow_up(&self) -> TemplateIter {
-        fhtml::concat! {
+    fn body_sections(&self) -> Vec<Box<dyn FnOnce() -> TemplateIter + Send>> {
+        body_section_once!(fhtml::concat! {
             <p>
                 "The adjustment introduces coordination at the boundary of execution.
                 Rather than optimizing the operation itself, it ensures identical work
@@ -88,8 +136,7 @@ impl Templater for EngineeringBlog {
             </p>
 
             <h2>"references"</h2>
-        }
-        .into()
+        })
     }
 
     fn tail(&self) -> TemplateIter {

--- a/src/response_templates/mod.rs
+++ b/src/response_templates/mod.rs
@@ -26,7 +26,7 @@ pub const CASUAL_STYLES: &[&str] = &[
     include_str!("styles/simple.css"),
     include_str!("styles/code-blog.css"),
 ];
-pub const ACADEMIC_STYLES: &[&str] = &[include_str!("styles/professor.css")];
+pub const ACADEMIC_STYLES: &[&str] = &[include_str!("styles/geriatric-professor.css")];
 pub const ENTERPRISE_STYLES: &[&str] = &[
     include_str!("styles/vibe-slop.css"),
     include_str!("styles/elegant.css"),
@@ -34,15 +34,16 @@ pub const ENTERPRISE_STYLES: &[&str] = &[
 
 #[cfg(test)]
 mod test {
-    use crate::templating::TemplateBuilder;
+    use std::iter::once;
 
     use super::*;
+    use crate::templating::TemplateBuilder;
 
     #[test]
     fn all_templates_produce_valid_documents() {
         // Do multiple iterations per template.
         // Since there is random generation in the templating logic - this helps catch more bugs.
-        let test_iterations = 100;
+        let test_iterations = 250;
 
         for _ in 0..test_iterations {
             for (ind, (template_constructor, _)) in
@@ -50,8 +51,13 @@ mod test {
             {
                 let builder = TemplateBuilder::with_template(template_constructor());
                 let document = builder
-                    .start_to_poison()
-                    .chain(builder.poison_to_links())
+                    .start_to_body()
+                    .chain(
+                        builder
+                            .body_sections()
+                            .flat_map(|s| once(s.pre_poison().into()).chain(s.post_poison())),
+                    )
+                    .chain(once(builder.body_to_links().into()))
                     .chain(builder.links_to_end())
                     .collect::<String>();
 
@@ -61,6 +67,15 @@ mod test {
                     "template at index {ind}: {errors:?} - {document:?}"
                 );
             }
+        }
+    }
+
+    #[test]
+    // Ensures that all templates will produce a document with at least one poison block.
+    fn all_templates_contain_body_sections() {
+        for (template_constructor, _) in RESPONSE_TEMPLATE_CONSTRUCTORS {
+            let template = template_constructor();
+            assert!(!template.body_sections().is_empty());
         }
     }
 

--- a/src/response_templates/research.rs
+++ b/src/response_templates/research.rs
@@ -12,12 +12,14 @@ mod link_headings;
 mod research_topics;
 mod slot;
 
+use field::Field;
 use slot::Slot;
 
 use fhtml::concat as el;
-use field::Field;
+use rand::random_range;
 
 use crate::{
+    body_section_once,
     response_templates::research::{
         code_explanation::{CODE_HEADINGS, CODE_INTRODUCTIONS},
         conclusions::CONCLUSION_OPTIONS,
@@ -139,13 +141,26 @@ impl Templater for NovelResearch {
                 *utils::select_random(CODE_INTRODUCTIONS),
                 &self.research_topic,
             ),
-            el!(</p>),
-            el!(<hr>),
+            el! {
+                </p>
+                <hr>
+                <figure>
+            },
         )
     }
 
-    fn follow_up(&self) -> TemplateIter {
-        template_iter!(
+    fn body_sections<'a>(&'a self) -> Vec<Box<dyn FnOnce() -> TemplateIter + Send + 'a>> {
+        body_section_once!(
+            el!(<figcaption>),
+            format!(
+                "Figure {}. {}",
+                random_range(1..=5),
+                utils::select_random(CODE_HEADINGS),
+            ),
+            el! {
+                </figcaption>
+            </figure>
+            },
             el!(<hr>),
             self.conclusion(),
             el! {

--- a/src/response_templates/research/conclusions.rs
+++ b/src/response_templates/research/conclusions.rs
@@ -182,7 +182,7 @@ pub const CONCLUSION_OPTIONS: &[&[Slot]] = &[
         Slot::Str(", especially for "),
         Slot::Topic,
         Slot::Str(
-            " The measured outcomes confirm progress toward more effective and robust solutions. \
+            ". The measured outcomes confirm progress toward more effective and robust solutions. \
             We expect the analytical framing and evaluation protocol to be useful beyond the immediate application scope.",
         ),
     ],

--- a/src/response_templates/self_promotion.rs
+++ b/src/response_templates/self_promotion.rs
@@ -1,4 +1,7 @@
-use crate::templating::{TemplateIter, TemplateTone, Templater};
+use crate::{
+    body_section_once,
+    templating::{TemplateIter, TemplatePart, TemplateTone, Templater},
+};
 
 pub struct SelfPromotion;
 
@@ -53,11 +56,10 @@ impl Templater for SelfPromotion {
         .into()
     }
 
-    fn follow_up(&self) -> TemplateIter {
-        fhtml::concat! {
+    fn body_sections(&self) -> Vec<Box<dyn FnOnce() -> TemplateIter + Send>> {
+        body_section_once!(fhtml::concat! {
             <h2>"Even more examples of my engineering prowess"</h2>
-        }
-        .into()
+        })
     }
 
     fn tail(&self) -> TemplateIter {

--- a/src/response_templates/streaming_marketing.rs
+++ b/src/response_templates/streaming_marketing.rs
@@ -1,4 +1,7 @@
-use crate::templating::{TemplateIter, TemplateTone, Templater};
+use crate::{
+    body_section_once,
+    templating::{TemplateIter, TemplatePart, TemplateTone, Templater},
+};
 
 pub struct StreamingMarketing;
 
@@ -49,8 +52,8 @@ impl Templater for StreamingMarketing {
         .into()
     }
 
-    fn follow_up(&self) -> TemplateIter {
-        fhtml::concat! {
+    fn body_sections(&self) -> Vec<Box<dyn FnOnce() -> TemplateIter + Send>> {
+        body_section_once!(fhtml::concat! {
           <section>
             <p>
                 "The implementation introduces a coordination layer between the player
@@ -93,8 +96,7 @@ impl Templater for StreamingMarketing {
                 streaming architectures, particularly during high-concurrency events
                 where others degrade and we remain stable."
             </p>
-        }
-        .into()
+        })
     }
 
     fn tail(&self) -> TemplateIter {

--- a/src/response_templates/styles/geriatric-professor.css
+++ b/src/response_templates/styles/geriatric-professor.css
@@ -12,3 +12,7 @@ a {
 a:visited {
   color: #551a8b;
 }
+figure {
+  margin-right: 0px;
+  margin-left: 0px;
+}

--- a/src/templating/mod.rs
+++ b/src/templating/mod.rs
@@ -16,6 +16,7 @@ pub use template_trait::Templater;
 pub use tone::TemplateTone;
 
 #[macro_export]
+#[doc(hidden)]
 /// Construct a `TemplateIter` from the inner contents.
 /// `TemplateIter` and `TemplatePart` must be imported and in scope.
 macro_rules! template_iter {
@@ -25,5 +26,23 @@ macro_rules! template_iter {
                 TemplatePart::from($part),
             )*
         ])
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+/// Construct a `Vec<Box<dyn FnOnce() -> TemplateIter>>` from the inner contents.
+/// `TemplateIter` and `TemplatePart` must be imported and in scope.
+macro_rules! body_section_once {
+    ($($part:expr),* $(,)?) => {
+        vec![
+            std::boxed::Box::new(move ||
+                TemplateIter::new(vec![
+                    $(
+                        TemplatePart::from($part),
+                    )*
+                ])
+            )
+        ]
     };
 }

--- a/src/templating/template_builder.rs
+++ b/src/templating/template_builder.rs
@@ -2,7 +2,10 @@ use std::borrow::Cow;
 
 use rand::seq::IndexedRandom;
 
-use crate::{response_templates::RESPONSE_TEMPLATE_CONSTRUCTORS, templating::Templater};
+use crate::{
+    response_templates::RESPONSE_TEMPLATE_CONSTRUCTORS,
+    templating::{TemplateIter, Templater},
+};
 
 pub struct TemplateBuilder {
     template: Box<dyn Templater>,
@@ -20,6 +23,25 @@ macro_rules! html {
     }};
 }
 
+pub struct BodySection<'a>(Box<dyn FnOnce() -> TemplateIter + Send + 'a>);
+impl BodySection<'_> {
+    #[expect(clippy::unused_self)]
+    pub fn pre_poison(&self) -> &'static str {
+        fhtml::concat! {
+            <pre style="white-space: pre-wrap">
+                <code>
+        }
+    }
+
+    pub fn post_poison(self) -> impl Iterator<Item = Cow<'static, str>> {
+        html! {
+                </code>
+            </pre>
+        }
+        .chain(self.0())
+    }
+}
+
 impl TemplateBuilder {
     pub fn with_random_template() -> Self {
         Self {
@@ -30,6 +52,7 @@ impl TemplateBuilder {
         }
     }
 
+    #[cfg(test)]
     pub fn with_template(template: Box<dyn Templater>) -> Self {
         Self { template }
     }
@@ -39,7 +62,7 @@ impl TemplateBuilder {
         self.template.tone().random_link_title()
     }
 
-    pub fn start_to_poison(&self) -> impl Iterator<Item = Cow<'static, str>> {
+    pub fn start_to_body(&self) -> impl Iterator<Item = Cow<'static, str>> {
         html! {
             <!DOCTYPE html>
             <html lang="en">
@@ -60,22 +83,18 @@ impl TemplateBuilder {
             <body>
         })
         .chain(self.template.introduction())
-        .chain(html! {
-                <pre style="white-space: pre-wrap">
-                    <code>
-        })
     }
 
-    pub fn poison_to_links(&self) -> impl Iterator<Item = Cow<'static, str>> {
-        html! {
-                    </code>
-                </pre>
-        }
-        .chain(self.template.follow_up())
-        .chain(html! {
-                <ul>
-        })
+    pub fn body_sections(&self) -> impl Iterator<Item = BodySection<'_>> {
+        self.template.body_sections().into_iter().map(BodySection)
     }
+
+    pub fn body_to_links(&self) -> &'static str {
+        fhtml::concat! {
+                <ul>
+        }
+    }
+
     pub fn links_to_end(&self) -> impl Iterator<Item = Cow<'static, str>> {
         html! {
                 </ul>
@@ -90,6 +109,8 @@ impl TemplateBuilder {
 
 #[cfg(test)]
 mod test {
+    use std::iter::once;
+
     use super::*;
     use crate::templating::*;
 
@@ -108,8 +129,11 @@ mod test {
         fn introduction(&self) -> TemplateIter {
             "test-intro".into()
         }
-        fn follow_up(&self) -> TemplateIter {
-            "test-follow-up".into()
+        fn body_sections(&self) -> Vec<Box<dyn FnOnce() -> TemplateIter + Send>> {
+            vec![
+                Box::new(|| "test-body-section-1".into()),
+                Box::new(|| "test-body-section-2".into()),
+            ]
         }
         fn tail(&self) -> TemplateIter {
             "test-tail".into()
@@ -123,9 +147,13 @@ mod test {
         };
 
         let actual = builder
-            .start_to_poison()
-            .chain(cow_iter!("POISON"))
-            .chain(builder.poison_to_links())
+            .start_to_body()
+            .chain(builder.body_sections().flat_map(|s| {
+                once(s.pre_poison().into())
+                    .chain(cow_iter!("POISON"))
+                    .chain(s.post_poison())
+            }))
+            .chain(cow_iter!(builder.body_to_links()))
             .chain(cow_iter!("LINKS"))
             .chain(builder.links_to_end())
             .collect::<String>();
@@ -146,7 +174,13 @@ mod test {
                         "POISON"
                     </code>
                 </pre>
-                "test-follow-up"
+                "test-body-section-1"
+                <pre style="white-space: pre-wrap">
+                    <code>
+                        "POISON"
+                    </code>
+                </pre>
+                "test-body-section-2"
                 <ul>
                     "LINKS"
                 </ul>
@@ -163,8 +197,13 @@ mod test {
             template: Box::new(MockTemplate),
         };
         let document = builder
-            .start_to_poison()
-            .chain(builder.poison_to_links())
+            .start_to_body()
+            .chain(builder.body_sections().flat_map(|s| {
+                once(s.pre_poison().into())
+                    .chain(cow_iter!("POISON"))
+                    .chain(s.post_poison())
+            }))
+            .chain(cow_iter!(builder.body_to_links()))
             .chain(builder.links_to_end())
             .collect::<String>();
 

--- a/src/templating/template_iter.rs
+++ b/src/templating/template_iter.rs
@@ -12,6 +12,16 @@ use crate::templating::TemplatePart;
 /// let manually = TemplateIter::new(vec!["<span>Hello </span>".into(), "<span>world!</span>".into()]);
 /// let nested = TemplateIter::new(vec![TemplateIter::new(vec!["<p>Hello world!</p>".into()]).into()]);
 /// ```
+///
+/// ```
+/// use miasma::templating::{TemplateIter, TemplatePart};
+/// use miasma::template_iter;
+///
+/// let with_macro: TemplateIter = template_iter! {
+///     "<p>Hello world!</p>",
+///     "<div>Goodbye</div>"
+/// };
+/// ```
 #[derive(Default)]
 pub struct TemplateIter {
     current: usize,
@@ -28,25 +38,20 @@ impl Iterator for TemplateIter {
     type Item = Cow<'static, str>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        #[allow(clippy::question_mark)]
-        let next = match self.parts.get_mut(self.current) {
-            None => return None,
-            Some(p) => match p {
-                TemplatePart::String(s) => {
+        match self.parts.get_mut(self.current)? {
+            TemplatePart::String(s) => {
+                self.current += 1;
+                Some(mem::take(s))
+            }
+            #[allow(clippy::single_match_else)]
+            TemplatePart::Iter(i) => match i.next() {
+                Some(s) => Some(s),
+                None => {
                     self.current += 1;
-                    mem::take(s)
+                    self.next()
                 }
-                #[allow(clippy::single_match_else)]
-                TemplatePart::Iter(i) => match i.next() {
-                    Some(s) => s,
-                    None => {
-                        self.current += 1;
-                        return self.next();
-                    }
-                },
             },
-        };
-        Some(next)
+        }
     }
 }
 

--- a/src/templating/template_trait.rs
+++ b/src/templating/template_trait.rs
@@ -12,8 +12,10 @@ use crate::templating::{TemplateIter, TemplateTone};
 ///   </head>
 ///   <body>
 ///     {Templater::introduction}
-///     <code>{POISON}</code>
-///     {Templater::follow_up}
+///     {for section in Templater::body_sections() {
+///       <code>{POISON}</code>
+///       {section}
+///     }}
 ///     <ul>{LINKS}</ul>
 ///     {Templater::tail}
 ///   </body>
@@ -44,14 +46,31 @@ pub trait Templater: Send + Sync {
     /// ```
     fn introduction(&self) -> TemplateIter;
 
-    /// Content following the poisoned data up to the generated links.
+    /// Content placed after each block of poisoned data. We've chosen to return a vec of functions
+    /// here to allow for lazy evaluation of each section iterator.
     ///
+    /// The number of items returned determines the number of poisoned code blocks that will be included in the final response.
+    ///
+    /// For example, a vec with a single item:
     /// ```html
     /// <code>{POISON}</code>
-    /// {FOLLOW_UP_VALUE}
+    /// {ITEM}
     /// <ul>{LINKS}</ul>
     /// ```
-    fn follow_up(&self) -> TemplateIter;
+    ///
+    /// A vec with three items:
+    /// ```html
+    /// <code>{POISON_1}</code>
+    /// {ITEM_1}
+    /// <code>{POISON_2}</code>
+    /// {ITEM_2}
+    /// <code>{POISON_3}</code>
+    /// {ITEM_3}
+    /// <ul>{LINKS}</ul>
+    /// ```
+    ///
+    /// _Implementers should return a vec with at least one item._
+    fn body_sections<'a>(&'a self) -> Vec<Box<dyn FnOnce() -> TemplateIter + Send + 'a>>;
 
     /// Content at the end of the document following the generated links.
     /// This method is optional and defaults to an empty string.


### PR DESCRIPTION
Refactored the `Templater` trait to allow for future templates to respond with multiple poison-blocks per response. Implemented with lazy evaluation so any String allocation in each body section are deferred until _after_ the full poison stream is sent, and are immediately dropped before the next section.
